### PR TITLE
Get rid of missing newline error in clang.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ NOTE: please use them in this order.
 
 [diff v1.0.3...main](https://github.com/rstcheck/rstcheck-core/compare/v1.0.3...main)
 
+### Miscellaneous
+
+- Ignore "no newline at end of file" errors when C++ code is checked by clang (such as on macOS)
+
 ## [1.0.3 (2022-11-12)](https://github.com/rstcheck/rstcheck-core/releases/v1.0.3)
 
 [diff v1.0.2...v1.0.3](https://github.com/rstcheck/rstcheck-core/compare/v1.0.2...v1.0.3)

--- a/docs/source/spelling_dict.txt
+++ b/docs/source/spelling_dict.txt
@@ -48,6 +48,7 @@ kwarg
 kwargs
 linter
 linters
+macOS
 makefile
 monkypatch
 monkypatched

--- a/src/rstcheck_core/checker.py
+++ b/src/rstcheck_core/checker.py
@@ -763,7 +763,9 @@ class CodeBlockChecker:
         """
         logger.debug("Check C++ source.")
         yield from self._gcc_checker(
-            source_code,
+            # Add a newline to ignore "no newline at end of file" errors
+            # that are reported using clang (e.g. on macOS).
+            source_code + "\n",
             ".cpp",
             [os.getenv("CXX", "g++")]
             + shlex.split(os.getenv("CXXFLAGS", ""))

--- a/tests/integration_tests/test_file_checker.py
+++ b/tests/integration_tests/test_file_checker.py
@@ -123,7 +123,6 @@ class TestWithoutConfigFile:
     """Test without config file in dir tree."""
 
     @staticmethod
-    @pytest.mark.skipif(sys.platform == "darwin", reason="MacOS specific variant exists")
     def test_error_without_config_file() -> None:
         """Test bad example without set config file and implicit config file shows errors."""
         test_file = EXAMPLES_DIR / "without_configuration" / "bad.rst"
@@ -132,21 +131,6 @@ class TestWithoutConfigFile:
         result = checker.check_file(test_file, init_config)
 
         assert len(result) == 6
-
-    @staticmethod
-    @pytest.mark.skipif(sys.platform != "darwin", reason="MacOS specific error count")
-    def test_error_without_config_file_macos() -> None:
-        """Test bad example without set config file and implicit config file shows errors.
-
-        On MacOS the cpp code block generates an additional error compared to linux:
-        ``(ERROR/3) (cpp) warning: no newline at end of file [-Wnewline-eof]``
-        """
-        test_file = EXAMPLES_DIR / "without_configuration" / "bad.rst"
-        init_config = config.RstcheckConfig()
-
-        result = checker.check_file(test_file, init_config)
-
-        assert len(result) == 7
 
     @staticmethod
     def test_no_error_with_set_ini_config_file() -> None:
@@ -192,7 +176,6 @@ class TestWithConfigFile:
     """Test with config file in dir tree."""
 
     @staticmethod
-    @pytest.mark.skipif(sys.platform == "darwin", reason="MacOS specific variant exists")
     def test_file_1_is_bad_without_config() -> None:
         """Test bad file ``bad.rst`` without config file is not ok."""
         test_file = EXAMPLES_DIR / "with_configuration" / "bad.rst"
@@ -201,21 +184,6 @@ class TestWithConfigFile:
         result = checker.check_file(test_file, init_config)
 
         assert len(result) == 6
-
-    @staticmethod
-    @pytest.mark.skipif(sys.platform != "darwin", reason="MacOS specific error count")
-    def test_file_1_is_bad_without_config_macos() -> None:
-        """Test bad file ``bad.rst`` without config file is not ok.
-
-        On MacOS the cpp code block generates an additional error compared to linux:
-        ``(ERROR/3) (cpp) warning: no newline at end of file [-Wnewline-eof]``
-        """
-        test_file = EXAMPLES_DIR / "with_configuration" / "bad.rst"
-        init_config = config.RstcheckConfig(config_path=pathlib.Path("NONE"))
-
-        result = checker.check_file(test_file, init_config)
-
-        assert len(result) == 7
 
     @staticmethod
     def test_file_2_is_bad_without_config() -> None:

--- a/tests/integration_tests/test_runner.py
+++ b/tests/integration_tests/test_runner.py
@@ -213,7 +213,6 @@ class TestWithoutConfigFile:
     """Test without config file in dir tree."""
 
     @staticmethod
-    @pytest.mark.skipif(sys.platform == "darwin", reason="MacOS specific variant exists")
     def test_error_without_config_file(capsys: pytest.CaptureFixture[str]) -> None:
         """Test bad example without set config file and implicit config file shows errors."""
         test_file = EXAMPLES_DIR / "without_configuration" / "bad.rst"
@@ -224,23 +223,6 @@ class TestWithoutConfigFile:
 
         assert result != 0
         assert len(ERROR_CODE_REGEX.findall(capsys.readouterr().err)) == 6
-
-    @staticmethod
-    @pytest.mark.skipif(sys.platform != "darwin", reason="MacOS specific error count")
-    def test_error_without_config_file_macos(capsys: pytest.CaptureFixture[str]) -> None:
-        """Test bad example without set config file and implicit config file shows errors.
-
-        On MacOS the cpp code block generates an additional error compared to linux:
-        ``(ERROR/3) (cpp) warning: no newline at end of file [-Wnewline-eof]``
-        """
-        test_file = EXAMPLES_DIR / "without_configuration" / "bad.rst"
-        init_config = config.RstcheckConfig()
-        _runner = runner.RstcheckMainRunner(check_paths=[test_file], rstcheck_config=init_config)
-
-        result = _runner.run()
-
-        assert result != 0
-        assert len(ERROR_CODE_REGEX.findall(capsys.readouterr().err)) == 7
 
     @staticmethod
     def test_no_error_with_set_ini_config_file(capsys: pytest.CaptureFixture[str]) -> None:
@@ -287,7 +269,6 @@ class TestWithConfigFile:
     """Test with config file in dir tree."""
 
     @staticmethod
-    @pytest.mark.skipif(sys.platform == "darwin", reason="MacOS specific variant exists")
     def test_file_1_is_bad_without_config(capsys: pytest.CaptureFixture[str]) -> None:
         """Test bad file ``bad.rst`` without config file is not ok."""
         test_file = EXAMPLES_DIR / "with_configuration" / "bad.rst"
@@ -299,24 +280,6 @@ class TestWithConfigFile:
 
         assert result != 0
         assert len(ERROR_CODE_REGEX.findall(capsys.readouterr().err)) == 6
-
-    @staticmethod
-    @pytest.mark.skipif(sys.platform != "darwin", reason="MacOS specific error count")
-    def test_file_1_is_bad_without_config_macos(capsys: pytest.CaptureFixture[str]) -> None:
-        """Test bad file ``bad.rst`` without config file is not ok.
-
-        On MacOS the cpp code block generates an additional error compared to linux:
-        ``(ERROR/3) (cpp) warning: no newline at end of file [-Wnewline-eof]``
-        """
-        test_file = EXAMPLES_DIR / "with_configuration" / "bad.rst"
-        config_file = pathlib.Path("NONE")
-        init_config = config.RstcheckConfig(config_path=config_file)
-        _runner = runner.RstcheckMainRunner(check_paths=[test_file], rstcheck_config=init_config)
-
-        result = _runner.run()
-
-        assert result != 0
-        assert len(ERROR_CODE_REGEX.findall(capsys.readouterr().err)) == 7
 
     @staticmethod
     def test_file_2_is_bad_without_config(capsys: pytest.CaptureFixture[str]) -> None:


### PR DESCRIPTION
On Darwin, executing g++ runs clang, which emits an error when a C++ code block does not end in a newline. This is different from how g++ behaves on Linux.

This error doesn't add any value in the context of a code block in an RST file, so we just always add a newline to the C++ source code of a block to get rid of it.

<!-- markdownlint-disable MD033 -->
<!-- PLEASE READ !!!

    The checklist below is just a reminder about the most common mistakes.
    and should *not* deter you from submitting but rather *help* you improve your contribution.
    But please tick all the boxes appropriately.

-->

# Check List

Resolves: https://github.com/rstcheck/rstcheck-core/issues/19

- [ ] I added **tests** for the changed code.
- [ ] I updated the **documentation** for the changed code.
- [ ] I ran the **full** `tox` test suite locally, so the CI pipelines should be green.
- [x] I added the change to the CHANGELOG.md file.

<!--
    Please add further information below that may help
    the maintainers understand what you intend to solve.
-->
