### PR TITLE
Update pydantic dependency to >= 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ NOTE: please use them in this order.
 ### Miscellaneous
 
 - Ignore "no newline at end of file" errors when C++ code is checked by clang (such as on macOS) ([#45](https://github.com/rstcheck/rstcheck-core/pull/45))
+- Update `pydantic` dependency to >= 2.0.
 
 ## [1.0.3 (2022-11-12)](https://github.com/rstcheck/rstcheck-core/releases/v1.0.3)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ importlib-metadata = {version = ">=1.6, <5.0", python = "<3.8"}
 typing-extensions = {version = ">=3.7.4, <5.0", python = "<3.8"}
 docutils = ">=0.7, <0.20"
 types-docutils = ">=0.18,<0.21"
-pydantic = ">=1.2, <2.0"
+pydantic = ">=2.1,<3.0"
 
 [tool.poetry.dev-dependencies]
 pre-commit = ">=2.17"

--- a/src/rstcheck_core/config.py
+++ b/src/rstcheck_core/config.py
@@ -83,15 +83,15 @@ class RstcheckConfigFile(pydantic.BaseModel):  # pylint: disable=no-member
     :raises pydantic.error_wrappers.ValidationError: If setting is not parsable into correct type
     """
 
-    report_level: t.Optional[ReportLevel]
-    ignore_directives: t.Optional[t.List[str]]
-    ignore_roles: t.Optional[t.List[str]]
-    ignore_substitutions: t.Optional[t.List[str]]
-    ignore_languages: t.Optional[t.List[str]]
+    report_level: t.Optional[ReportLevel] = None
+    ignore_directives: t.Optional[t.List[str]] = None
+    ignore_roles: t.Optional[t.List[str]] = None
+    ignore_substitutions: t.Optional[t.List[str]] = None
+    ignore_languages: t.Optional[t.List[str]] = None
     # NOTE: Pattern type-arg errors pydanic: https://github.com/samuelcolvin/pydantic/issues/2636
-    ignore_messages: t.Optional[t.Pattern]  # type: ignore[type-arg]
+    ignore_messages: t.Optional[t.Pattern] = None  # type: ignore[type-arg]
 
-    @pydantic.validator("report_level", pre=True)
+    @pydantic.field_validator("report_level", mode="before")
     @classmethod
     def valid_report_level(cls, value: t.Any) -> t.Optional[ReportLevel]:  # noqa: ANN401
         """Validate the report_level setting.
@@ -124,8 +124,12 @@ class RstcheckConfigFile(pydantic.BaseModel):  # pylint: disable=no-member
 
         raise ValueError("Invalid report level")
 
-    @pydantic.validator(
-        "ignore_directives", "ignore_roles", "ignore_substitutions", "ignore_languages", pre=True
+    @pydantic.field_validator(
+        "ignore_directives",
+        "ignore_roles",
+        "ignore_substitutions",
+        "ignore_languages",
+        mode="before",
     )
     @classmethod
     def split_str(cls, value: t.Any) -> t.Optional[t.List[str]]:  # noqa: ANN401
@@ -144,7 +148,7 @@ class RstcheckConfigFile(pydantic.BaseModel):  # pylint: disable=no-member
         """
         return _split_str_validator(value)
 
-    @pydantic.validator("ignore_messages", pre=True)
+    @pydantic.field_validator("ignore_messages", mode="before")
     @classmethod
     def join_regex_str(
         cls, value: t.Any  # noqa: ANN401
@@ -180,9 +184,9 @@ class RstcheckConfig(RstcheckConfigFile):  # pylint: disable=too-few-public-meth
     :raises pydantic.error_wrappers.ValidationError: If setting is not parsable into correct type
     """
 
-    config_path: t.Optional[pathlib.Path]
-    recursive: t.Optional[bool]
-    warn_unknown_settings: t.Optional[bool]
+    config_path: t.Optional[pathlib.Path] = None
+    recursive: t.Optional[bool] = None
+    warn_unknown_settings: t.Optional[bool] = None
 
 
 class _RstcheckConfigINIFile(
@@ -195,12 +199,12 @@ class _RstcheckConfigINIFile(
     :raises pydantic.error_wrappers.ValidationError: If setting is not parsable into correct type
     """
 
-    report_level: pydantic.NoneStr = pydantic.Field(None)  # pylint: disable=no-member
-    ignore_directives: pydantic.NoneStr = pydantic.Field(None)  # pylint: disable=no-member
-    ignore_roles: pydantic.NoneStr = pydantic.Field(None)  # pylint: disable=no-member
-    ignore_substitutions: pydantic.NoneStr = pydantic.Field(None)  # pylint: disable=no-member
-    ignore_languages: pydantic.NoneStr = pydantic.Field(None)  # pylint: disable=no-member
-    ignore_messages: pydantic.NoneStr = pydantic.Field(None)  # pylint: disable=no-member
+    report_level: t.Optional[str] = None  # pylint: disable=no-member
+    ignore_directives: t.Optional[str] = None  # pylint: disable=no-member
+    ignore_roles: t.Optional[str] = None  # pylint: disable=no-member
+    ignore_substitutions: t.Optional[str] = None  # pylint: disable=no-member
+    ignore_languages: t.Optional[str] = None  # pylint: disable=no-member
+    ignore_messages: t.Optional[str] = None  # pylint: disable=no-member
 
 
 def _load_config_from_ini_file(


### PR DESCRIPTION
<!-- markdownlint-disable MD033 -->
<!-- PLEASE READ !!!

    The checklist below is just a reminder about the most common mistakes.
    and should *not* deter you from submitting but rather *help* you improve your contribution.
    But please tick all the boxes appropriately.

-->

# Check List

Resolves: #<issue number here>

- [ ] I added **tests** for the changed code.
- [ ] I updated the **documentation** for the changed code.
- [x] I ran the **full** `tox` test suite locally, so the CI pipelines should be green.
- [x] I added the change to the CHANGELOG.md file.

<!--
    Please add further information below that may help
    the maintainers understand what you intend to solve.
-->

I tried adapting the code for pydantic >= 2. However, there are still weird warnings in the `docs-*` tox targets that I can not figure out, so those will likely fail.
```
WARNING: Failed guarded type import with ImportError("cannot import name 'AbstractSetIntStr' from 'pydantic._internal._utils' (/home/user/rstcheck-core/.tox/docs/lib/python3.11/site-packages/pydantic/_internal/_utils.py)")
```
AFAICT, the type in question is not directly used in this code base but might be dragged in by something else. I can't figure out from where and how to not have the tox targets fail on this. Some feedback would be greatly appreciated!

Closes #44 