### PR TITLE
Add support for yaml code block checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ NOTE: please use them in this order.
 ### Miscellaneous
 
 - Remove unused pre python 3.8 compatibility code ([#74](https://github.com/rstcheck/rstcheck/pull/74))
+- Add optional YAML code block support ([#77](https://github.com/rstcheck/rstcheck-core/issues/77))
 
 ## [1.1.1 (2023-09-09)](https://github.com/rstcheck/rstcheck-core/releases/v1.1.1)
 

--- a/README.rst
+++ b/README.rst
@@ -44,6 +44,9 @@ To add sphinx support::
 
     $ pip install rstcheck_core[sphinx]
 
+To add YAML checking support::
+
+    $ pip install rstcheck_core[yaml]
 
 Supported languages in code blocks
 ==================================
@@ -56,6 +59,7 @@ Supported languages in code blocks
 - XML
 - Python
 - reStructuredText
+- YAML
 
 
 .. _read-the-docs: https://rstcheck-core.readthedocs.io

--- a/docs/source/usage/config.rst
+++ b/docs/source/usage/config.rst
@@ -302,6 +302,7 @@ Supported languages are:
 - XML
 - Python
 - reStructuredText
+- YAML
 
 
 Ignore specific error messages

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ docs = [
 type-check = [
   "mypy >=1.0",
   "types-docutils >=0.18",
+  "types-PyYAML >=6.0.0",
 ]
 dev = [
   "rstcheck-core[sphinx,toml,testing,docs,type-check,yaml]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
 [project.optional-dependencies]
 sphinx = ["sphinx >=4.0"]
 toml = ["tomli >=2.0; python_version<='3.10'"]
+yaml = ["pyyaml >= 6.0.0"]
 testing = [
     "pytest >=7.2",
     "pytest-cov >=3.0",
@@ -53,7 +54,7 @@ type-check = [
   "types-docutils >=0.18",
 ]
 dev = [
-  "rstcheck-core[sphinx,toml,testing,docs,type-check]",
+  "rstcheck-core[sphinx,toml,testing,docs,type-check,yaml]",
   "tox >=3.15",
 ]
 

--- a/src/rstcheck_core/checker.py
+++ b/src/rstcheck_core/checker.py
@@ -24,12 +24,15 @@ import docutils.io
 import docutils.nodes
 import docutils.utils
 
+from . import _docutils, _extras, _sphinx, config, inline_config, types
+
 try:
     import yaml
-except ImportError:
-    yaml = None
 
-from . import _docutils, _extras, _sphinx, config, inline_config, types
+    yaml_imported = True
+except ImportError:
+    yaml_imported = False
+
 
 logger = logging.getLogger(__name__)
 
@@ -681,7 +684,7 @@ class CodeBlockChecker:
         :return: :py:obj:`None`
         :yield: Found issues
         """
-        if not yaml:
+        if not yaml_imported:
             logger.debug("PyYAML is not installed, ignoring YAML source.")
             return
         logger.debug("Check YAML source.")

--- a/src/rstcheck_core/checker.py
+++ b/src/rstcheck_core/checker.py
@@ -24,6 +24,11 @@ import docutils.io
 import docutils.nodes
 import docutils.utils
 
+try:
+    import yaml
+except ImportError:
+    yaml = None
+
 from . import _docutils, _extras, _sphinx, config, inline_config, types
 
 logger = logging.getLogger(__name__)
@@ -661,6 +666,28 @@ class CodeBlockChecker:
         try:
             json.loads(source_code)
         except ValueError as exception:
+            message = f"{exception}"
+            found = EXCEPTION_LINE_NO_REGEX.search(message)
+            line_number = int(found.group(1)) if found else 0
+
+            yield types.LintError(
+                source_origin=self.source_origin, line_number=int(line_number), message=message
+            )
+
+    def check_yaml(self, source_code: str) -> types.YieldedLintError:
+        """Check YAML source for syntax errors.
+
+        :param source: JSON source code to check
+        :return: :py:obj:`None`
+        :yield: Found issues
+        """
+        if not yaml:
+            logger.debug("PyYAML is not installed, ignoring YAML source.")
+            return
+        logger.debug("Check YAML source.")
+        try:
+            yaml.safe_load(source_code)
+        except yaml.error.YAMLError as exception:
             message = f"{exception}"
             found = EXCEPTION_LINE_NO_REGEX.search(message)
             line_number = int(found.group(1)) if found else 0

--- a/tests/checker_test.py
+++ b/tests/checker_test.py
@@ -7,6 +7,7 @@ import re
 import shlex
 import sys
 from inspect import isfunction
+from unittest import mock
 
 import docutils.io
 import docutils.nodes
@@ -772,6 +773,61 @@ if mystring is "ok":
 
         assert len(result) == 1
         assert "Expecting value:" in result[0]["message"]
+
+    @staticmethod
+    def test_check_yaml_returns_none_on_ok_code_block_no_pyyaml() -> None:
+        """Test ``check_json`` returns ``None`` on ok code block."""
+        source = """
+spam: ham
+eggs: ham
+"""
+        with mock.patch.object(checker, "yaml", None):
+            cb_checker = checker.CodeBlockChecker("<string>")
+
+            result = list(cb_checker.check_yaml(source))
+
+        assert not result
+
+    @staticmethod
+    def test_check_yaml_returns_ok_on_bad_code_block_no_pyyaml() -> None:
+        """Test ``check_json`` returns error on bad code block."""
+        source = """
+spam: ham
+  eggs: ham
+"""
+        with mock.patch.object(checker, "yaml", None):
+            cb_checker = checker.CodeBlockChecker("<string>")
+
+            result = list(cb_checker.check_yaml(source))
+
+        assert not result
+
+    @staticmethod
+    def test_check_yaml_returns_none_on_ok_code_block() -> None:
+        """Test ``check_json`` returns ``None`` on ok code block."""
+        source = """
+spam: ham
+eggs: ham
+"""
+        cb_checker = checker.CodeBlockChecker("<string>")
+
+        result = list(cb_checker.check_yaml(source))
+
+        assert not result
+
+    @staticmethod
+    def test_check_yaml_returns_error_on_bad_code_block() -> None:
+        """Test ``check_json`` returns error on bad code block."""
+        source = """
+spam: ham
+  eggs: ham
+"""
+        cb_checker = checker.CodeBlockChecker("<string>")
+
+        result = list(cb_checker.check_yaml(source))
+
+        assert len(result) == 1
+        assert "mapping values are not allowed here" in result[0]["message"]
 
     @staticmethod
     def test_check_xml_returns_none_on_ok_code_block() -> None:

--- a/tests/checker_test.py
+++ b/tests/checker_test.py
@@ -6,8 +6,8 @@ import pathlib
 import re
 import shlex
 import sys
+import typing as t
 from inspect import isfunction
-from unittest import mock
 
 import docutils.io
 import docutils.nodes
@@ -15,6 +15,9 @@ import docutils.utils
 import pytest
 
 from rstcheck_core import _extras, _sphinx, checker, config, types
+
+if t.TYPE_CHECKING:
+    import pytest_mock
 
 
 def test_check_file(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -775,30 +778,34 @@ if mystring is "ok":
         assert "Expecting value:" in result[0]["message"]
 
     @staticmethod
-    def test_check_yaml_returns_none_on_ok_code_block_no_pyyaml() -> None:
+    def test_check_yaml_returns_none_on_ok_code_block_no_pyyaml(
+        mocker: pytest_mock.MockerFixture,
+    ) -> None:
         """Test ``check_json`` returns ``None`` on ok code block."""
         source = """
 spam: ham
 eggs: ham
 """
-        with mock.patch.object(checker, "yaml", None):
-            cb_checker = checker.CodeBlockChecker("<string>")
+        mocker.patch.object(checker, "yaml_imported", False)  # noqa: FBT003
+        cb_checker = checker.CodeBlockChecker("<string>")
 
-            result = list(cb_checker.check_yaml(source))
+        result = list(cb_checker.check_yaml(source))
 
         assert not result
 
     @staticmethod
-    def test_check_yaml_returns_ok_on_bad_code_block_no_pyyaml() -> None:
+    def test_check_yaml_returns_ok_on_bad_code_block_no_pyyaml(
+        mocker: pytest_mock.MockerFixture,
+    ) -> None:
         """Test ``check_json`` returns error on bad code block."""
         source = """
 spam: ham
   eggs: ham
 """
-        with mock.patch.object(checker, "yaml", None):
-            cb_checker = checker.CodeBlockChecker("<string>")
+        mocker.patch.object(checker, "yaml_imported", False)  # noqa: FBT003
+        cb_checker = checker.CodeBlockChecker("<string>")
 
-            result = list(cb_checker.check_yaml(source))
+        result = list(cb_checker.check_yaml(source))
 
         assert not result
 

--- a/tox.ini
+++ b/tox.ini
@@ -118,6 +118,7 @@ set_env =
     COVERAGE_FILE = {env:COVERAGE_FILE:{toxinidir}/.coverage_cache/.coverage.{envname}}
 extras =
     testing
+    yaml
 commands =
     pytest \
         {tty:--color yes:{env:CI_FORCE_COLORS_PYTEST:}} \
@@ -138,6 +139,7 @@ set_env =
     COVERAGE_FILE = {env:COVERAGE_FILE:{toxinidir}/.coverage_cache/.coverage.{envname}}
 extras =
     testing
+    yaml
 deps =
     sphinx4: sphinx>=4,<5
     sphinx5: sphinx>=5,<6
@@ -164,6 +166,7 @@ set_env =
 extras =
     toml
     testing
+    yaml
 commands =
     pytest \
         {tty:--color yes:{env:CI_FORCE_COLORS_PYTEST:}} \


### PR DESCRIPTION
runs a yaml.safe_load on a YAML code block for a minimal structure sanity check, skipped if pyyaml is not installed.

<!-- markdownlint-disable MD033 -->
<!-- PLEASE READ !!!

    The checklist below is just a reminder about the most common mistakes.
    and should *not* deter you from submitting but rather *help* you improve your contribution.
    But please tick all the boxes appropriately.

-->

# Check List

Resolves: #77 

- [ x] I added **tests** for the changed code.
- [ x] I updated the **documentation** for the changed code.
- [ x] I ran the **full** `tox` test suite locally, so the CI pipelines should be green.
- [ x] I added the change to the CHANGELOG.md file.

<!--
    Please add further information below that may help
    the maintainers understand what you intend to solve.
-->
