### PR TITLE
Feature/issue68 support for adding sphinx directives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,6 @@ NOTE: please use them in this order.
 
 [diff v1.2.0...main](https://github.com/rstcheck/rstcheck-core/compare/v1.2.0...main)
 
-
 ### New features
 
 - Support for linting of non-standard sphinx directives with rst content ([#68](https://github.com/rstcheck/rstcheck-core/issues/68))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ NOTE: please use them in this order.
 
 [diff v1.2.0...main](https://github.com/rstcheck/rstcheck-core/compare/v1.2.0...main)
 
+### New features
+
+- Support for linting of non-standard sphinx directives with rst content ([#68](https://github.com/rstcheck/rstcheck-core/issues/68))
+
 ## [1.2.0 (2023-11-13)](https://github.com/rstcheck/rstcheck-core/releases/v1.2.0)
 
 [diff vv1.1.1...v1.2.0](https://github.com/rstcheck/rstcheck-core/compare/vv1.1.1...v1.2.0)

--- a/src/rstcheck_core/_sphinx.py
+++ b/src/rstcheck_core/_sphinx.py
@@ -7,6 +7,10 @@ import pathlib
 import tempfile
 import typing as t
 
+import docutils.parsers.rst.directives
+from docutils.frontend import OptionParser
+from docutils.utils import new_document
+
 from . import _docutils, _extras
 
 if _extras.SPHINX_INSTALLED:
@@ -17,6 +21,8 @@ if _extras.SPHINX_INSTALLED:
     import sphinx.domains.python
     import sphinx.domains.std
     import sphinx.util.docutils
+    from sphinx.parsers import RSTParser
+    from sphinx.util.docutils import SphinxDirective
 
 
 logger = logging.getLogger(__name__)
@@ -44,8 +50,15 @@ def load_sphinx_if_available() -> t.Generator[sphinx.application.Sphinx | None, 
     if _extras.SPHINX_INSTALLED:
         create_dummy_sphinx_app()
         # NOTE: Hack to prevent sphinx warnings for overwriting registered nodes; see #113
+        overridden_extensions = [
+            "sphinx.addnodes",
+            "sphinx.domains.math",
+            "sphinx.domains.index",
+            "sphinx.domains.changeset"
+        ]
         sphinx.application.builtin_extensions = [
-            e for e in sphinx.application.builtin_extensions if e != "sphinx.addnodes"  # type: ignore[assignment]
+            e for e in sphinx.application.builtin_extensions
+            if e not in overridden_extensions
         ]
 
     yield None
@@ -114,3 +127,54 @@ def load_sphinx_ignores() -> None:  # pragma: no cover
     (directives, roles) = filter_whitelisted_directives_and_roles(directives, roles)
 
     _docutils.ignore_directives_and_roles(directives, roles)
+
+
+app = None
+
+if _extras.SPHINX_INSTALLED:
+
+    with load_sphinx_if_available() as loaded_sphinx_app:
+        if loaded_sphinx_app is not None:
+            app = loaded_sphinx_app
+        else:
+            app = create_dummy_sphinx_app()
+
+    class AddSphinxDirective(SphinxDirective):
+        has_content = True
+
+        def run(self) -> t.List:
+            return self.parse_rst(self.content)
+
+        def parse_rst(self, text):
+            parser = RSTParser()
+            parser.set_application(app)
+
+            settings = OptionParser(
+                defaults={},
+                components=(RSTParser,),
+                read_config_files=True,
+            ).get_default_values()
+            document = new_document("<rst-doc>", settings=settings)
+            parser.parse(text, document)
+            return document.children
+
+else:
+
+    class AddSphinxDirective(docutils.parsers.rst.Directive):
+        has_content = True
+
+        def run(self) -> t.List:  # type: ignore[type-arg]
+            return []
+
+
+def add_sphinx_directives(directives: t.Optional[t.List[str]]) -> None:
+    if directives is None:
+        return
+    _extras.install_guard("sphinx")
+
+    if _extras.SPHINX_INSTALLED and app is not None:
+        for directive in directives:
+            if directive in docutils.parsers.rst.directives._directives:
+                continue
+
+            app.add_directive(directive, AddSphinxDirective)

--- a/src/rstcheck_core/_sphinx.py
+++ b/src/rstcheck_core/_sphinx.py
@@ -54,11 +54,10 @@ def load_sphinx_if_available() -> t.Generator[sphinx.application.Sphinx | None, 
             "sphinx.addnodes",
             "sphinx.domains.math",
             "sphinx.domains.index",
-            "sphinx.domains.changeset"
+            "sphinx.domains.changeset",
         ]
         sphinx.application.builtin_extensions = [
-            e for e in sphinx.application.builtin_extensions
-            if e not in overridden_extensions
+            e for e in sphinx.application.builtin_extensions if e not in overridden_extensions
         ]
 
     yield None
@@ -132,7 +131,6 @@ def load_sphinx_ignores() -> None:  # pragma: no cover
 app = None
 
 if _extras.SPHINX_INSTALLED:
-
     with load_sphinx_if_available() as loaded_sphinx_app:
         if loaded_sphinx_app is not None:
             app = loaded_sphinx_app
@@ -142,7 +140,7 @@ if _extras.SPHINX_INSTALLED:
     class AddSphinxDirective(SphinxDirective):
         has_content = True
 
-        def run(self) -> t.List:
+        def run(self) -> list:
             return self.parse_rst(self.content)
 
         def parse_rst(self, text):
@@ -163,11 +161,11 @@ else:
     class AddSphinxDirective(docutils.parsers.rst.Directive):
         has_content = True
 
-        def run(self) -> t.List:  # type: ignore[type-arg]
+        def run(self) -> list:  # type: ignore[type-arg]
             return []
 
 
-def add_sphinx_directives(directives: t.Optional[t.List[str]]) -> None:
+def add_sphinx_directives(directives: t.Optional[list[str]]) -> None:
     if directives is None:
         return
     _extras.install_guard("sphinx")

--- a/src/rstcheck_core/checker.py
+++ b/src/rstcheck_core/checker.py
@@ -76,7 +76,7 @@ def check_file(
                 ignores=ignore_dict,
                 report_level=run_config.report_level or config.DEFAULT_REPORT_LEVEL,
                 warn_unknown_settings=run_config.warn_unknown_settings or False,
-                add_directives=run_config.add_directives
+                add_directives=run_config.add_directives,
             )
         )
 
@@ -163,7 +163,7 @@ def check_source(
     report_level: config.ReportLevel = config.DEFAULT_REPORT_LEVEL,
     *,
     warn_unknown_settings: bool = False,
-    add_directives: t.Optional[t.List[str]] = []
+    add_directives: t.Optional[list[str]] = [],
 ) -> types.YieldedLintError:
     """Check the given rst source for issues.
 

--- a/src/rstcheck_core/checker.py
+++ b/src/rstcheck_core/checker.py
@@ -76,7 +76,7 @@ def check_file(
                 ignores=ignore_dict,
                 report_level=run_config.report_level or config.DEFAULT_REPORT_LEVEL,
                 warn_unknown_settings=run_config.warn_unknown_settings or False,
-                add_directives=run_config.add_directives
+                add_directives=run_config.add_directives,
             )
         )
 
@@ -163,7 +163,7 @@ def check_source(
     report_level: config.ReportLevel = config.DEFAULT_REPORT_LEVEL,
     *,
     warn_unknown_settings: bool = False,
-    add_directives: t.Optional[t.List[str]] = []
+    add_directives: list[str] | None = None,
 ) -> types.YieldedLintError:
     """Check the given rst source for issues.
 

--- a/src/rstcheck_core/checker.py
+++ b/src/rstcheck_core/checker.py
@@ -76,6 +76,7 @@ def check_file(
                 ignores=ignore_dict,
                 report_level=run_config.report_level or config.DEFAULT_REPORT_LEVEL,
                 warn_unknown_settings=run_config.warn_unknown_settings or False,
+                add_directives=run_config.add_directives
             )
         )
 
@@ -162,6 +163,7 @@ def check_source(
     report_level: config.ReportLevel = config.DEFAULT_REPORT_LEVEL,
     *,
     warn_unknown_settings: bool = False,
+    add_directives: t.Optional[t.List[str]] = []
 ) -> types.YieldedLintError:
     """Check the given rst source for issues.
 
@@ -213,6 +215,7 @@ def check_source(
 
     if _extras.SPHINX_INSTALLED:
         _sphinx.load_sphinx_ignores()
+        _sphinx.add_sphinx_directives(add_directives)
 
     writer = _CheckWriter(source, source_origin, ignores, report_level)
 
@@ -224,7 +227,7 @@ def check_source(
     with contextlib.suppress(UnicodeError):
         source = source.encode("utf-8").decode("utf-8-sig")
 
-    with contextlib.suppress(docutils.utils.SystemMessage):
+    with contextlib.redirect_stderr(string_io):
         # Sphinx will sometimes throw an `AttributeError` trying to access
         # "self.state.document.settings.env". Ignore this for now until we
         # figure out a better approach.

--- a/src/rstcheck_core/config.py
+++ b/src/rstcheck_core/config.py
@@ -91,6 +91,7 @@ class RstcheckConfigFile(pydantic.BaseModel):
     ignore_substitutions: t.Optional[t.List[str]] = None  # noqa: UP007,UP006
     ignore_languages: t.Optional[t.List[str]] = None  # noqa: UP007,UP006
     ignore_messages: t.Optional[t.Pattern[str]] = None  # noqa: UP007
+    add_directives: t.Optional[t.List[str]] = None  # noqa: UP007,UP006
 
     @pydantic.field_validator("report_level", mode="before")
     @classmethod
@@ -134,6 +135,7 @@ class RstcheckConfigFile(pydantic.BaseModel):
         "ignore_roles",
         "ignore_substitutions",
         "ignore_languages",
+        "add_directives",
         mode="before",
     )
     @classmethod
@@ -144,6 +146,7 @@ class RstcheckConfigFile(pydantic.BaseModel):
         - ignore_roles
         - ignore_substitutions
         - ignore_languages
+        - add_directives
 
         Comma separated strings are split into a list.
 
@@ -207,6 +210,7 @@ class _RstcheckConfigINIFile(pydantic.BaseModel):
     ignore_substitutions: t.Optional[str] = None  # noqa: UP007
     ignore_languages: t.Optional[str] = None  # noqa: UP007
     ignore_messages: t.Optional[str] = None  # noqa: UP007
+    add_directives: t.Optional[str] = None  # noqa: UP007
 
 
 def _load_config_from_ini_file(
@@ -287,6 +291,7 @@ class _RstcheckConfigTOMLFile(
     ignore_substitutions: t.Optional[t.List[str]] = None  # noqa: UP006, UP007
     ignore_languages: t.Optional[t.List[str]] = None  # noqa: UP006, UP007
     ignore_messages: t.Union[t.List[str], str, None] = None  # noqa: UP006, UP007
+    add_directives: t.Optional[t.List[str]] = None  # noqa: UP006, UP007
 
 
 def _load_config_from_toml_file(

--- a/testing/examples/sphinx/add_directive_test.rst
+++ b/testing/examples/sphinx/add_directive_test.rst
@@ -1,0 +1,46 @@
+====
+Test
+====
+
+.. req:: test add directives
+    :id: REQ_cVcB6E4I
+    :name: test req
+    description
+    - list item 1
+          - list item 2
+    - list item 3
+
+    .. req:: A custom requirement with picture
+      :author: daniel
+      :id: EX_REQ_4
+      :tags: example
+      :status: open
+      :layout: example
+      :style yellow, blue_border
+
+    This example uses the value from **author** to reference an image.
+        See :ref:`layouts_styles` for the complete explanation.
+
+    .. req:: A requirement with a permalink
+      :id: EX_REQ_5
+      :tags: example
+      :status: open
+      :layout: permalink_example
+
+.. code:: python
+    print(
+
+.. spec:: Nested Spec Need
+   :id: JINJAID125
+   :status: open
+   :tags: user;login
+   :links: JINJAID126
+   :jinja_content: true
+
+   Nested need with ``:jinja_content:`` option set to ``true``.
+   This requirement has tags: **{{ tags | join(', ') }}**.
+
+   It links to:
+   {% for link in links %%%}
+      - {{ link }}
+   {% endfor %}

--- a/testing/examples/sphinx/unknown_directive_test.rst
+++ b/testing/examples/sphinx/unknown_directive_test.rst
@@ -1,0 +1,9 @@
+====
+Test
+====
+
+.. req:: test unknown directive type
+    :id: REQ_2j3uki
+    :name: test req
+
+    description

--- a/tests/_sphinx_test.py
+++ b/tests/_sphinx_test.py
@@ -167,27 +167,26 @@ class TestDirectiveAndRoleFilter:
 
 
 class TestAddSphinxDirectives:
-    """Test add_directives option in rstcheck""" 
+    """Test add_directives option in rstcheck."""
 
     @staticmethod
     @pytest.mark.skipif(not _extras.SPHINX_INSTALLED, reason="Depends on sphinx extra.")
     def test_unknown_directive_type(capsys: pytest.CaptureFixture[str]) -> None:
         test_file = EXAMPLES_DIR / "sphinx" / "unknown_directive_test.rst"
         init_config = config.RstcheckConfig()
-        all_errors: t.List[types.LintError] = list(checker.check_file(test_file, init_config))
+        all_errors: list[types.LintError] = list(checker.check_file(test_file, init_config))
         assert all_errors
 
         error_req = 'Unknown directive type "req"'
-        assert any(error_req in res['message'] for res in all_errors)
+        assert any(error_req in res["message"] for res in all_errors)
 
     @staticmethod
     @pytest.mark.skipif(not _extras.SPHINX_INSTALLED, reason="Depends on sphinx extra.")
     def test_add_directives(capsys: pytest.CaptureFixture[str]) -> None:
-        """If add_directives were added to config, lint error must be raised"""
         test_file = EXAMPLES_DIR / "sphinx" / "add_directive_test.rst"
         init_config = config.RstcheckConfig(add_directives=["req", "spec"])
-        all_errors: t.List[types.LintError] = list(checker.check_file(test_file, init_config))
+        all_errors: list[types.LintError] = list(checker.check_file(test_file, init_config))
         assert all_errors
 
-        error_req = '(ERROR/3) Unexpected indentation'
-        assert any(error_req in res['message'] for res in all_errors)
+        error_req = "(ERROR/3) Unexpected indentation"
+        assert any(error_req in res["message"] for res in all_errors)

--- a/tests/_sphinx_test.py
+++ b/tests/_sphinx_test.py
@@ -167,18 +167,18 @@ class TestDirectiveAndRoleFilter:
 
 
 class TestAddSphinxDirectives:
-    """Test add_directives option in rstcheck""" 
+    """Test add_directives option in rstcheck"""
 
     @staticmethod
     @pytest.mark.skipif(not _extras.SPHINX_INSTALLED, reason="Depends on sphinx extra.")
     def test_unknown_directive_type(capsys: pytest.CaptureFixture[str]) -> None:
         test_file = EXAMPLES_DIR / "sphinx" / "unknown_directive_test.rst"
         init_config = config.RstcheckConfig()
-        all_errors: t.List[types.LintError] = list(checker.check_file(test_file, init_config))
+        all_errors: list[types.LintError] = list(checker.check_file(test_file, init_config))
         assert all_errors
 
         error_req = 'Unknown directive type "req"'
-        assert any(error_req in res['message'] for res in all_errors)
+        assert any(error_req in res["message"] for res in all_errors)
 
     @staticmethod
     @pytest.mark.skipif(not _extras.SPHINX_INSTALLED, reason="Depends on sphinx extra.")
@@ -186,8 +186,8 @@ class TestAddSphinxDirectives:
         """If add_directives were added to config, lint error must be raised"""
         test_file = EXAMPLES_DIR / "sphinx" / "add_directive_test.rst"
         init_config = config.RstcheckConfig(add_directives=["req", "spec"])
-        all_errors: t.List[types.LintError] = list(checker.check_file(test_file, init_config))
+        all_errors: list[types.LintError] = list(checker.check_file(test_file, init_config))
         assert all_errors
 
-        error_req = '(ERROR/3) Unexpected indentation'
-        assert any(error_req in res['message'] for res in all_errors)
+        error_req = "(ERROR/3) Unexpected indentation"
+        assert any(error_req in res["message"] for res in all_errors)

--- a/tests/_sphinx_test.py
+++ b/tests/_sphinx_test.py
@@ -7,7 +7,8 @@ import docutils.parsers.rst.directives as docutils_directives
 import docutils.parsers.rst.roles as docutils_roles
 import pytest
 
-from rstcheck_core import _extras, _sphinx
+from rstcheck_core import _extras, _sphinx, checker, config, types
+from tests.conftest import EXAMPLES_DIR
 
 if _extras.SPHINX_INSTALLED:
     import sphinx.application
@@ -163,3 +164,30 @@ class TestDirectiveAndRoleFilter:
 
         assert "test-role" not in result_roles
         assert "test-role2" in result_roles
+
+
+class TestAddSphinxDirectives:
+    """Test add_directives option in rstcheck""" 
+
+    @staticmethod
+    @pytest.mark.skipif(not _extras.SPHINX_INSTALLED, reason="Depends on sphinx extra.")
+    def test_unknown_directive_type(capsys: pytest.CaptureFixture[str]) -> None:
+        test_file = EXAMPLES_DIR / "sphinx" / "unknown_directive_test.rst"
+        init_config = config.RstcheckConfig()
+        all_errors: t.List[types.LintError] = list(checker.check_file(test_file, init_config))
+        assert all_errors
+
+        error_req = 'Unknown directive type "req"'
+        assert any(error_req in res['message'] for res in all_errors)
+
+    @staticmethod
+    @pytest.mark.skipif(not _extras.SPHINX_INSTALLED, reason="Depends on sphinx extra.")
+    def test_add_directives(capsys: pytest.CaptureFixture[str]) -> None:
+        """If add_directives were added to config, lint error must be raised"""
+        test_file = EXAMPLES_DIR / "sphinx" / "add_directive_test.rst"
+        init_config = config.RstcheckConfig(add_directives=["req", "spec"])
+        all_errors: t.List[types.LintError] = list(checker.check_file(test_file, init_config))
+        assert all_errors
+
+        error_req = '(ERROR/3) Unexpected indentation'
+        assert any(error_req in res['message'] for res in all_errors)

--- a/tests/checker_test.py
+++ b/tests/checker_test.py
@@ -30,7 +30,7 @@ def test_check_file(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         checker,
         "check_source",
-        lambda _, source_file, ignores, report_level, warn_unknown_settings: (e for e in errors),
+        lambda _, source_file, ignores, report_level, warn_unknown_settings, add_directives=None: (e for e in errors), 
     )
     test_config = config.RstcheckConfig(config_path=pathlib.Path())
 

--- a/tests/checker_test.py
+++ b/tests/checker_test.py
@@ -30,7 +30,9 @@ def test_check_file(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         checker,
         "check_source",
-        lambda _, source_file, ignores, report_level, warn_unknown_settings, add_directives=None: (e for e in errors), 
+        lambda _, source_file, ignores, report_level, warn_unknown_settings, add_directives=None: (
+            e for e in errors
+        ),
     )
     test_config = config.RstcheckConfig(config_path=pathlib.Path())
 

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -37,6 +37,7 @@ def test_default_values_for_config_file() -> None:
     assert result.ignore_substitutions is None
     assert result.ignore_languages is None
     assert result.ignore_messages is None
+    assert result.add_directives is None
 
 
 def test_default_values_for_config() -> None:
@@ -52,6 +53,7 @@ def test_default_values_for_config() -> None:
     assert result.ignore_messages is None
     assert result.config_path is None
     assert result.recursive is None
+    assert result.add_directives is None
 
 
 class TestSplitStrValidator:
@@ -188,6 +190,7 @@ class TestSplitStrValidatorMethod:
     - ``ignore_roles``
     - ``ignore_substitutions``
     - ``ignore_languages``
+    - ``add_directives``
 
     settings.
     """
@@ -200,6 +203,7 @@ class TestSplitStrValidatorMethod:
             ignore_directives=None,
             ignore_roles=None,
             ignore_substitutions=None,
+            add_directives=None
         )
 
         assert result is not None
@@ -207,6 +211,7 @@ class TestSplitStrValidatorMethod:
         assert result.ignore_directives is None
         assert result.ignore_roles is None
         assert result.ignore_substitutions is None
+        assert result.add_directives is None
 
     @staticmethod
     @pytest.mark.parametrize(
@@ -231,6 +236,7 @@ class TestSplitStrValidatorMethod:
             ignore_directives=string,
             ignore_roles=string,
             ignore_substitutions=string,
+            add_directives=string
         )
 
         assert result is not None
@@ -238,6 +244,7 @@ class TestSplitStrValidatorMethod:
         assert result.ignore_directives == split_list
         assert result.ignore_roles == split_list
         assert result.ignore_substitutions == split_list
+        assert result.add_directives == split_list
 
     @staticmethod
     @pytest.mark.parametrize(
@@ -259,6 +266,7 @@ class TestSplitStrValidatorMethod:
             ignore_directives=string_list,
             ignore_roles=string_list,
             ignore_substitutions=string_list,
+            add_directives=string_list
         )
 
         assert result is not None
@@ -266,6 +274,7 @@ class TestSplitStrValidatorMethod:
         assert result.ignore_directives == string_list_cleaned
         assert result.ignore_roles == string_list_cleaned
         assert result.ignore_substitutions == string_list_cleaned
+        assert result.add_directives == string_list_cleaned
 
     @staticmethod
     @pytest.mark.parametrize(
@@ -290,6 +299,7 @@ class TestSplitStrValidatorMethod:
                 ignore_directives=value,
                 ignore_roles=value,
                 ignore_substitutions=value,
+                add_directives=value
             )
 
 
@@ -446,6 +456,7 @@ class TestIniFileLoader:
         ignore_substitutions=substitution
         ignore_languages=language
         ignore_messages=message
+        add_directives=add_directive
         """
         conf_file.write_text(file_content)
         regex = re.compile("message")
@@ -459,6 +470,7 @@ class TestIniFileLoader:
         assert result.ignore_substitutions == ["substitution"]
         assert result.ignore_languages == ["language"]
         assert result.ignore_messages == regex
+        assert result.add_directives == ["add_directive"]
 
     @staticmethod
     def test_multiline_strings(tmp_path: pathlib.Path) -> None:
@@ -470,6 +482,7 @@ class TestIniFileLoader:
             role1,
             role2,
             role3
+        add_directives=add_directive
         """
         conf_file.write_text(file_content)
 
@@ -478,6 +491,7 @@ class TestIniFileLoader:
         assert result is not None
         assert result.ignore_directives == ["directive"]
         assert result.ignore_roles == ["role1", "role2", "role3"]
+        assert result.add_directives == ["add_directive"]
 
     @staticmethod
     def test_multiline_strings_trailing_comma(tmp_path: pathlib.Path) -> None:
@@ -489,6 +503,7 @@ class TestIniFileLoader:
             role1,
             role2,
             role3,
+        add_directives=add_directive
         """
         conf_file.write_text(file_content)
 
@@ -497,6 +512,7 @@ class TestIniFileLoader:
         assert result is not None
         assert result.ignore_directives == ["directive"]
         assert result.ignore_roles == ["role1", "role2", "role3"]
+        assert result.add_directives == ["add_directive"]
 
     @staticmethod
     def test_file_with_mixed_supported_settings(tmp_path: pathlib.Path) -> None:
@@ -506,6 +522,7 @@ class TestIniFileLoader:
         report_level=3
         ignore_directives=directive
         unsupported_feature=True
+        add_directives=req,req-sw
         """
         conf_file.write_text(file_content)
 
@@ -514,6 +531,7 @@ class TestIniFileLoader:
         assert result is not None
         assert result.report_level == config.ReportLevel.ERROR
         assert result.ignore_directives == ["directive"]
+        assert result.add_directives == ["req", "req-sw"]
 
     @staticmethod
     def test_file_with_mixed_supported_sections(tmp_path: pathlib.Path) -> None:
@@ -523,6 +541,7 @@ class TestIniFileLoader:
         report_level=3
         ignore_directives=directive
         unsupported_feature=True
+        add_directives=req,req-sw
 
         [not-rstcheck]
         report_level=2
@@ -536,6 +555,7 @@ class TestIniFileLoader:
         assert result is not None
         assert result.report_level == config.ReportLevel.ERROR
         assert result.ignore_directives == ["directive"]
+        assert result.add_directives == ["req", "req-sw"]
 
     @staticmethod
     def test_warning_is_logged_on_missing_section_by_default(

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -203,7 +203,7 @@ class TestSplitStrValidatorMethod:
             ignore_directives=None,
             ignore_roles=None,
             ignore_substitutions=None,
-            add_directives=None
+            add_directives=None,
         )
 
         assert result is not None
@@ -236,7 +236,7 @@ class TestSplitStrValidatorMethod:
             ignore_directives=string,
             ignore_roles=string,
             ignore_substitutions=string,
-            add_directives=string
+            add_directives=string,
         )
 
         assert result is not None
@@ -266,7 +266,7 @@ class TestSplitStrValidatorMethod:
             ignore_directives=string_list,
             ignore_roles=string_list,
             ignore_substitutions=string_list,
-            add_directives=string_list
+            add_directives=string_list,
         )
 
         assert result is not None
@@ -299,7 +299,7 @@ class TestSplitStrValidatorMethod:
                 ignore_directives=value,
                 ignore_roles=value,
                 ignore_substitutions=value,
-                add_directives=value
+                add_directives=value,
             )
 
 


### PR DESCRIPTION
- add a new configuration option to add sphinx directives 
- sphinx directives content is parsed to find RST and report syntax issues
- Implements #68 

# Check List

Resolves: #68 

- [x] I added **tests** for the changed code.
- [x] I updated the **documentation** for the changed code.
- [x] I ran the **full** `tox` test suite locally, so the CI pipelines should be green.
- [x] I added the change to the CHANGELOG.md file.


