### PR TITLE
[WIP] Add JSONc support

### DIFF
--- a/src/rstcheck_core/checker.py
+++ b/src/rstcheck_core/checker.py
@@ -682,6 +682,35 @@ class CodeBlockChecker:
                 source_origin=self.source_origin, line_number=int(line_number), message=message
             )
 
+    def check_jsonc(self, source_code: str) -> types.YieldedLintError:
+        """Check JSONC (JSON with comments) source for syntax errors.
+
+        :param source: JSONC source code to check
+        :return: :py:obj:`None`
+        :yield: Found issues
+        """
+        logger.debug("Check JSONC source.")
+        # strip comments from JSONc source then pass through the JSON validator;
+        # split and strip full line comments
+        source_lines = [
+            line for line in source_code.splitlines() if not line.strip().startswith("//")
+        ]
+        for ind, line in enumerate(source_lines):
+            if "//" in line:
+                source_lines[ind] = line.split("//")[0].strip()
+        source_code = "\n".join(source_lines)
+
+        try:
+            json.loads(source_code)
+        except ValueError as exception:
+            message = f"{exception}"
+            found = EXCEPTION_LINE_NO_REGEX.search(message)
+            line_number = int(found.group(1)) if found else 0
+
+            yield types.LintError(
+                source_origin=self.source_origin, line_number=int(line_number), message=message
+            )
+
     def check_yaml(self, source_code: str) -> types.YieldedLintError:
         """Check YAML source for syntax errors.
 

--- a/tests/checker_test.py
+++ b/tests/checker_test.py
@@ -779,6 +779,78 @@ if mystring is "ok":
         assert "Expecting value:" in result[0]["message"]
 
     @staticmethod
+    def test_check_jsonc_returns_error_on_bad_code_block() -> None:
+        """Test ``check_jsonc`` returns error on bad code block."""
+        source = """
+{
+    "key":
+}
+"""
+        cb_checker = checker.CodeBlockChecker("<string>")
+
+        result = list(cb_checker.check_jsonc(source))
+
+        assert len(result) == 1
+        assert "Expecting value:" in result[0]["message"]
+
+    @staticmethod
+    def test_check_jsonc_returns_none_on_ok_code_block() -> None:
+        """Test ``check_jsonc`` returns ``None`` on ok code block."""
+        source = """
+{
+    "key": "value"
+}
+"""
+        cb_checker = checker.CodeBlockChecker("<string>")
+
+        result = list(cb_checker.check_jsonc(source))
+
+        assert not result
+
+    @staticmethod
+    def test_check_jsonc_returns_no_error_on_full_line_comment_block() -> None:
+        """Test ``check_jsonc`` returns error on bad code block."""
+        source = """
+{
+    // this key has an annotation
+    "key": "value"
+}
+"""
+        cb_checker = checker.CodeBlockChecker("<string>")
+
+        result = list(cb_checker.check_jsonc(source))
+
+        assert not result
+
+    @staticmethod
+    def test_check_jsonc_returns_no_error_on_inline_comment_block() -> None:
+        """Test ``check_jsonc`` returns error on bad code block."""
+        source = """
+{
+    "key": "value" // this key has an annotation
+}
+"""
+        cb_checker = checker.CodeBlockChecker("<string>")
+
+        result = list(cb_checker.check_jsonc(source))
+
+        assert not result
+
+    @staticmethod
+    def test_check_jsonc_returns_no_error_in_awkward_inline_comment_block() -> None:
+        """Test ``check_jsonc`` returns error on bad code block."""
+        source = """
+{
+        "key": "value", "next_key": "http://example.org", "//": "another_value", // this key has an annotation
+}
+"""
+        cb_checker = checker.CodeBlockChecker("<string>")
+
+        result = list(cb_checker.check_jsonc(source))
+
+        assert not result
+
+    @staticmethod
     @pytest.mark.skipif(checker.yaml_imported is False, reason="Requires pyyaml to be installed")
     def test_check_yaml_returns_none_on_ok_code_block_no_pyyaml(
         mocker: pytest_mock.MockerFixture,


### PR DESCRIPTION
<!-- markdownlint-disable MD033 -->
<!-- PLEASE READ !!!

    The checklist below is just a reminder about the most common mistakes.
    and should *not* deter you from submitting but rather *help* you improve your contribution.
    But please tick all the boxes appropriately.

-->

# Check List

Resolves: #92.

- [x] I added **tests** for the changed code.
- [ ] I updated the **documentation** for the changed code.
- [x] I ran the **full** `tox` test suite locally, so the CI pipelines should be green.
- [ ] I added the change to the CHANGELOG.md file.

This is still WIP as the case for handling inline comments is not covered (without breaking when e.g., `//` is used inside a key or value).

I'm also having a hard time finding a well-defined standard. https://komkom.github.io/jsonc/ provides some example for Go, and VSCode uses something pretty similar: https://code.visualstudio.com/docs/languages/json#_json-with-comments -- so the question how useful this really is depends on how widespread its usage is. 
