### PR TITLE
Fix attribute errors, address code-blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ NOTE: please use them in this order.
 - Update configs for dev tooling ([#96](https://github.com/rstcheck/rstcheck-core/pull/96))
 - Bump default python version to 3.12 ([#96](https://github.com/rstcheck/rstcheck-core/pull/96))
 
+### Bugfixes
+
+- Fix attribute errors with code-blocks and include when using sphinx ([#3](https://github.com/rstcheck/rstcheck-core/issues/3))
+
 ## [v1.2.1 (2024-03-23)](https://github.com/rstcheck/rstcheck-core/releases/v1.2.1)
 
 [diff v1.2.0...v1.2.1](https://github.com/rstcheck/rstcheck-core/compare/v1.2.0...v1.2.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ NOTE: please use them in this order.
 
 - Update configs for dev tooling ([#96](https://github.com/rstcheck/rstcheck-core/pull/96))
 - Bump default python version to 3.12 ([#96](https://github.com/rstcheck/rstcheck-core/pull/96))
+- Try to generate a line number for code blocks that don't have one
 
 ### Bugfixes
 

--- a/src/rstcheck_core/checker.py
+++ b/src/rstcheck_core/checker.py
@@ -70,16 +70,15 @@ def check_file(
 
     _docutils.clean_docutils_directives_and_roles_cache()
 
-    with _sphinx.load_sphinx_if_available():
-        return list(
-            check_source(
-                source,
-                source_file=source_file,
-                ignores=ignore_dict,
-                report_level=run_config.report_level or config.DEFAULT_REPORT_LEVEL,
-                warn_unknown_settings=run_config.warn_unknown_settings or False,
-            )
+    return list(
+        check_source(
+            source,
+            source_file=source_file,
+            ignores=ignore_dict,
+            report_level=run_config.report_level or config.DEFAULT_REPORT_LEVEL,
+            warn_unknown_settings=run_config.warn_unknown_settings or False,
         )
+    )
 
 
 def _load_run_config(
@@ -231,30 +230,16 @@ def check_source(
         # "self.state.document.settings.env". Ignore this for now until we
         # figure out a better approach.
         # https://github.com/rstcheck/rstcheck-core/issues/3
-        try:
-            docutils.core.publish_string(
-                source,
-                writer=writer,
-                source_path=str(source_origin),
-                settings_overrides={
-                    "halt_level": 5,
-                    "report_level": report_level.value,
-                    "warning_stream": string_io,
-                },
-            )
-        except AttributeError:
-            if not _extras.SPHINX_INSTALLED:
-                raise
-            logger.warning(
-                "An `AttributeError` error occured. This is most probably due to a code block "
-                "directive (code/code-block/sourcecode) without a specified language. "
-                "This may result in a false negative for source: '%s'. "
-                "The reason can also be another directive. "
-                "For more information see the FAQ (https://rstcheck-core.rtfd.io/en/latest/faq) "
-                "or the corresponding github issue: "
-                "https://github.com/rstcheck/rstcheck-core/issues/3.",
-                source_origin,
-            )
+        docutils.core.publish_string(
+            source,
+            writer=writer,
+            source_path=str(source_origin),
+            settings_overrides={
+                "halt_level": 5,
+                "report_level": report_level.value,
+                "warning_stream": string_io,
+            },
+        )
 
     yield from _run_code_checker_and_filter_errors(writer.checkers, ignores["messages"])
 
@@ -574,9 +559,6 @@ def _get_code_block_directive_line(node: docutils.nodes.Element, full_contents: 
     line_number = node.line
     if line_number is None:
         return None
-
-    if _extras.SPHINX_INSTALLED:
-        return line_number
 
     lines = full_contents.splitlines()
     for line_no in range(line_number, 1, -1):

--- a/src/rstcheck_core/runner.py
+++ b/src/rstcheck_core/runner.py
@@ -10,7 +10,7 @@ import re
 import sys
 import typing as t
 
-from . import _sphinx, checker, config, types
+from . import checker, config, types
 
 logger = logging.getLogger(__name__)
 
@@ -183,11 +183,10 @@ class RstcheckMainRunner:
         :return: List of lists of errors found per file
         """
         logger.debug("Runnning checks synchronically.")
-        with _sphinx.load_sphinx_if_available():
-            return [
-                checker.check_file(file, self.config, self.overwrite_config)
-                for file in self._files_to_check
-            ]
+        return [
+            checker.check_file(file, self.config, self.overwrite_config)
+            for file in self._files_to_check
+        ]
 
     def _run_checks_parallel(self) -> list[list[types.LintError]]:
         """Check all files from the file list in parallel and return the errors.
@@ -198,7 +197,7 @@ class RstcheckMainRunner:
             "Runnning checks in parallel with pool size of %s.",
             self._pool_size,
         )
-        with _sphinx.load_sphinx_if_available(), multiprocessing.Pool(self._pool_size) as pool:
+        with multiprocessing.Pool(self._pool_size) as pool:
             return pool.starmap(
                 checker.check_file,
                 [(file, self.config, self.overwrite_config) for file in self._files_to_check],

--- a/testing/examples/good/_include.rst
+++ b/testing/examples/good/_include.rst
@@ -1,0 +1,6 @@
+
+1. A list to indent.
+
+   .. code-block:: python
+
+      print()

--- a/testing/examples/good/code_blocks.rst
+++ b/testing/examples/good/code_blocks.rst
@@ -159,3 +159,5 @@ Run more tests for checking performance.
 
     # ¬∆˚ß∂ƒß∂ƒ˚¬∆
     print(1)
+
+.. include:: _include.rst

--- a/tests/_sphinx_test.py
+++ b/tests/_sphinx_test.py
@@ -4,47 +4,9 @@ from __future__ import annotations
 
 import typing as t
 
-import docutils.parsers.rst.directives as docutils_directives
-import docutils.parsers.rst.roles as docutils_roles
 import pytest
 
 from rstcheck_core import _extras, _sphinx
-
-if _extras.SPHINX_INSTALLED:
-    import sphinx.application
-
-
-@pytest.mark.skipif(not _extras.SPHINX_INSTALLED, reason="Depends on sphinx extra.")
-def test_dummy_app_creator() -> None:
-    """Test creation of dummy sphinx app."""
-    result = _sphinx.create_dummy_sphinx_app()
-
-    assert isinstance(result, sphinx.application.Sphinx)
-
-
-class TestContextManager:
-    """Test ``load_sphinx_if_available`` context manager."""
-
-    @staticmethod
-    @pytest.mark.skipif(_extras.SPHINX_INSTALLED, reason="Test without sphinx extra.")
-    @pytest.mark.usefixtures("patch_docutils_directives_and_roles_dict")
-    def test_yield_nothing_with_sphinx_missing() -> None:
-        """Test for ``None`` yield and no action when sphinx is missing."""
-        with _sphinx.load_sphinx_if_available() as ctx_manager:
-            assert ctx_manager is None
-            assert not docutils_directives._directives  # type: ignore[attr-defined]
-            assert not docutils_roles._roles  # type: ignore[attr-defined]
-
-    @staticmethod
-    @pytest.mark.skipif(not _extras.SPHINX_INSTALLED, reason="Depends on sphinx extra.")
-    @pytest.mark.usefixtures("patch_docutils_directives_and_roles_dict")
-    def test_yield_nothing_with_sphinx_installed() -> None:
-        """Test for ``None`` yield but action when sphinx is installed."""
-        with _sphinx.load_sphinx_if_available() as ctx_manager:
-            assert ctx_manager is None
-            assert docutils_directives._directives  # type: ignore[attr-defined]
-            assert docutils_roles._roles  # type: ignore[attr-defined]
-            assert "sphinx.addnodes" not in sphinx.application.builtin_extensions
 
 
 class TestSphinxDirectiveAndRoleGetter:

--- a/tests/checker_test.py
+++ b/tests/checker_test.py
@@ -15,7 +15,7 @@ import docutils.nodes
 import docutils.utils
 import pytest
 
-from rstcheck_core import _extras, _sphinx, checker, config, types
+from rstcheck_core import _extras, checker, config, types
 
 if t.TYPE_CHECKING:
     import pytest_mock
@@ -378,9 +378,6 @@ Test
     @staticmethod
     @pytest.mark.skipif(not _extras.SPHINX_INSTALLED, reason="Depends on sphinx extra.")
     @pytest.mark.skipif(sys.version_info[0:2] > (3, 9), reason="Requires python3.9 or lower")
-    @pytest.mark.xfail(
-        reason="Sphinx support fails for language-less code blocks. See #3", strict=True
-    )
     @pytest.mark.parametrize("code_block_directive", ["code", "code-block", "sourcecode"])
     def test_code_block_without_language_is_works_with_sphinx_pre310(
         code_block_directive: str,
@@ -397,21 +394,16 @@ Test
 """
         ignores = types.construct_ignore_dict()
         # fmt: off
-        with _sphinx.load_sphinx_if_available():
-
-            result = list(checker.check_source(source, ignores=ignores))
+        result = list(checker.check_source(source, ignores=ignores))
 
         # fmt: on
         assert len(result) == 1
-        assert result[0]["line_number"] == 9
+        assert result[0]["line_number"] == 8
         assert "unexpected EOF while parsing" in result[0]["message"]
 
     @staticmethod
     @pytest.mark.skipif(not _extras.SPHINX_INSTALLED, reason="Depends on sphinx extra.")
     @pytest.mark.skipif(sys.version_info < (3, 10), reason="Requires python3.10 or higher")
-    @pytest.mark.xfail(
-        reason="Sphinx support fails for language-less code blocks. See #3", strict=True
-    )
     @pytest.mark.parametrize("code_block_directive", ["code", "code-block", "sourcecode"])
     def test_code_block_without_language_is_works_with_sphinx(
         code_block_directive: str,
@@ -428,13 +420,11 @@ Test
 """
         ignores = types.construct_ignore_dict()
         # fmt: off
-        with _sphinx.load_sphinx_if_available():
-
-            result = list(checker.check_source(source, ignores=ignores))
+        result = list(checker.check_source(source, ignores=ignores))
 
         # fmt: on
         assert len(result) == 1
-        assert result[0]["line_number"] == 9
+        assert result[0]["line_number"] == 8
         assert "'(' was never closed" in result[0]["message"]
 
     @staticmethod
@@ -459,9 +449,7 @@ Test
 """
         ignores = types.construct_ignore_dict()
         # fmt: off
-        with _sphinx.load_sphinx_if_available():
-
-            result = list(checker.check_source(source, ignores=ignores))
+        result = list(checker.check_source(source, ignores=ignores))
 
         # fmt: on
         assert result
@@ -469,37 +457,6 @@ Test
         assert (
             "directive (code/code-block/sourcecode) without a specified language" not in caplog.text
         )
-
-    @staticmethod
-    @pytest.mark.skipif(not _extras.SPHINX_INSTALLED, reason="Depends on sphinx extra.")
-    @pytest.mark.parametrize("code_block_directive", ["code", "code-block", "sourcecode"])
-    def test_code_block_without_language_logs_critcal_with_sphinx(
-        code_block_directive: str,
-        caplog: pytest.LogCaptureFixture,
-    ) -> None:
-        """Test code blocks without a language log critical and do not error with sphinx.
-
-        Counterpart to the XFAIL tests ``test_code_block_without_language_is_works_with_sphinx``.
-        """
-        source = f"""
-.. {code_block_directive}::
-
-    print(
-
-.. {code_block_directive}:: python
-
-    print(
-"""
-        ignores = types.construct_ignore_dict()
-        # fmt: off
-        with _sphinx.load_sphinx_if_available():
-
-            result = list(checker.check_source(source, ignores=ignores))
-
-        # fmt: on
-        assert not result
-        assert "An `AttributeError` error occured" in caplog.text
-        assert "directive (code/code-block/sourcecode) without a specified language" in caplog.text
 
 
 class TestCodeCheckRunner:


### PR DESCRIPTION
Take a stab at addressing the attribute errors in sphinx now by eliminating the dynamic loader. A single instance of sphinx will be created at launch if sphinx is present on the system.

Also, address the warning about being unable to determine the line of a code-block by generating one from the information available in the parent node.

Let me know if there's anything else that needs addressing here. This is the first project I've played with that uses tox.

Resolves: #3

- [x] I added **tests** for the changed code.
- [ ] I updated the **documentation** for the changed code.
- [x] I ran the **full** `tox` test suite locally, so the CI pipelines should be green.
- [x] I added the change to the CHANGELOG.md file.
