### PR TITLE
fix: strip include directives to prevent AttributeError in Sphinx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,9 @@ NOTE: please use them in this order.
 
 ### Bugfixes
 
-- Stripped `include` directives to prevent `AttributeError` in Sphinx ([#114](https://github.com/rstcheck/rstcheck-core/pull/114))
+- Stripped `include` directives to prevent `AttributeError` in Sphinx. Included files
+  are checked separately for existence and not just ignored.
+  ([#114](https://github.com/rstcheck/rstcheck-core/pull/114))
 
 ## [v1.2.2 (2025-06-01)](https://github.com/rstcheck/rstcheck-core/releases/v1.2.2)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ NOTE: please use them in this order.
 
 [diff v1.2.2...main](https://github.com/rstcheck/rstcheck-core/compare/v1.2.2...main)
 
+### Bugfixes
+
+- Stripped `include` directives to prevent `AttributeError` in Sphinx ([#114](https://github.com/rstcheck/rstcheck-core/pull/114))
+
 ## [v1.2.2 (2025-06-01)](https://github.com/rstcheck/rstcheck-core/releases/v1.2.2)
 
 [diff v1.2.1...v1.2.2](https://github.com/rstcheck/rstcheck-core/compare/v1.2.1...v1.2.2)

--- a/src/rstcheck_core/_sphinx_workarounds.py
+++ b/src/rstcheck_core/_sphinx_workarounds.py
@@ -1,0 +1,73 @@
+"""Sphinx workarounds for rstcheck."""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import typing as t
+
+from . import types
+
+_INCLUDE_REGEX = re.compile(
+    r"^([ \t]*)\.\.[ \t]+include::[ \t]+([^\n]+)(?:\n(?:[ \t]*$|\1[ \t]+(?:.*)))*",
+    flags=re.MULTILINE,
+)
+
+
+def strip_include_directives(source: str) -> str:
+    """Strip include directives from source to prevent Sphinx AttributeError.
+
+    Replaces the directive and its options with newlines to preserve line numbers.
+
+    :param source: Source to remove include directives from
+    :return: Cleaned source
+    """
+
+    def replacer(match: re.Match[str]) -> str:
+        return "\n" * match.group(0).count("\n")
+
+    return _INCLUDE_REGEX.sub(replacer, source)
+
+
+def yield_include_errors(
+    source: str,
+    source_origin: types.SourceFileOrString,
+    ignore_messages: t.Pattern[str] | None = None,
+) -> types.YieldedLintError:
+    """Check existence of included files from include directives.
+
+    :param source: Source containing include directives
+    :param source_origin: Origin of the source
+    :param ignore_messages: Regex for ignoring error messages; defaults to :py:obj:`None`
+    :return: :py:obj:`None`
+    :yield: Found issues
+    """
+    if isinstance(source_origin, pathlib.Path) and source_origin.name != "-":
+        base_dir = source_origin.parent
+    else:
+        base_dir = pathlib.Path.cwd()
+
+    for match in _INCLUDE_REGEX.finditer(source):
+        file_path_str = match.group(2).strip()
+
+        target_path = pathlib.Path(file_path_str)
+        if not target_path.is_absolute() and not (
+            file_path_str.startswith("<") and file_path_str.endswith(">")
+        ):
+            target_path = base_dir / target_path
+
+        if (
+            not (file_path_str.startswith("<") and file_path_str.endswith(">"))
+            and not target_path.is_file()
+        ):
+            line_number = source[: match.start()].count("\n") + 1
+            message = (
+                f"(SEVERE/4) File referenced in \"include\" directive not found: '{file_path_str}'."
+            )
+
+            if ignore_messages and ignore_messages.search(message):
+                continue
+
+            yield types.LintError(
+                source_origin=source_origin, line_number=line_number, message=message
+            )

--- a/src/rstcheck_core/checker.py
+++ b/src/rstcheck_core/checker.py
@@ -133,10 +133,11 @@ def _get_source(source_file: pathlib.Path) -> str:
 
 def _process_include_directives(
     source: str, source_origin: types.SourceFileOrString
-) -> (str, list[types.LintError]):
+) -> tuple[str, list[types.LintError]]:
     """Strip include directives from source and check existence of included files.
 
-    This is a workaround for Sphinx which raises AttributeError on encountering an include directive.
+    This is a workaround for Sphinx which raises AttributeError on
+    encountering an include directive.
 
     :param source: Source to remove include directives from
     :param source_origin: Origin of the source

--- a/src/rstcheck_core/checker.py
+++ b/src/rstcheck_core/checker.py
@@ -204,7 +204,9 @@ def check_source(
     )
 
     if _extras.SPHINX_INSTALLED:
-        yield from _sphinx_workarounds.yield_include_errors(source, source_origin, ignores["messages"])
+        yield from _sphinx_workarounds.yield_include_errors(
+            source, source_origin, ignores["messages"]
+        )
         source = _sphinx_workarounds.strip_include_directives(source)
 
     source = _replace_ignored_substitutions(source, ignores["substitutions"])

--- a/src/rstcheck_core/checker.py
+++ b/src/rstcheck_core/checker.py
@@ -131,7 +131,9 @@ def _get_source(source_file: pathlib.Path) -> str:
         return input_file.read()
 
 
-def _process_include_directives(source: str, source_origin: types.SourceFileOrString) -> (str, list[types.LintError]):
+def _process_include_directives(
+    source: str, source_origin: types.SourceFileOrString
+) -> (str, list[types.LintError]):
     """Strip include directives from source and check existence of included files.
 
     This is a workaround for Sphinx which raises AttributeError on encountering an include directive.
@@ -156,10 +158,19 @@ def _process_include_directives(source: str, source_origin: types.SourceFileOrSt
         ):
             target_path = base_dir / target_path
 
-        if not (file_path_str.startswith("<") and file_path_str.endswith(">")) and not target_path.is_file():
+        if (
+            not (file_path_str.startswith("<") and file_path_str.endswith(">"))
+            and not target_path.is_file()
+        ):
             line_number = source[: match.start()].count("\n") + 1
-            message = f'(SEVERE/4) File referenced in "include" directive not found: \'{file_path_str}\'.'
-            found_errors.append(types.LintError(source_origin=source_origin, line_number=line_number, message=message))
+            message = (
+                f"(SEVERE/4) File referenced in \"include\" directive not found: '{file_path_str}'."
+            )
+            found_errors.append(
+                types.LintError(
+                    source_origin=source_origin, line_number=line_number, message=message
+                )
+            )
 
         return ""
 

--- a/src/rstcheck_core/checker.py
+++ b/src/rstcheck_core/checker.py
@@ -42,6 +42,7 @@ logger = logging.getLogger(__name__)
 EXCEPTION_LINE_NO_REGEX = re.compile(r": line\s+([0-9]+)[^:]*$")
 DOCTEST_LINE_NO_REGEX = re.compile(r"line ([0-9]+)")
 MARKDOWN_LINK_REGEX = re.compile(r"\[[^\]]+\]\([^\)]+\)")
+INCLUDE_REGEX = re.compile(r"^([ \t]*\.\.[ \t]+include::)[ \t]+(.+)$", flags=re.MULTILINE)
 
 
 def check_file(
@@ -130,6 +131,42 @@ def _get_source(source_file: pathlib.Path) -> str:
         return input_file.read()
 
 
+def _process_include_directives(source: str, source_origin: types.SourceFileOrString) -> (str, list[types.LintError]):
+    """Strip include directives from source and check existence of included files.
+
+    This is a workaround for Sphinx which raises AttributeError on encountering an include directive.
+
+    :param source: Source to remove include directives from
+    :param source_origin: Origin of the source
+    :return: Tuple of cleaned source and found errors
+    """
+    found_errors: list[types.LintError] = []
+
+    def replace_include(match: re.Match[str]) -> str:
+        file_path_str = match.group(2).strip()
+
+        if isinstance(source_origin, pathlib.Path) and source_origin.name != "-":
+            base_dir = source_origin.parent
+        else:
+            base_dir = pathlib.Path.cwd()
+
+        target_path = pathlib.Path(file_path_str)
+        if not target_path.is_absolute() and not (
+            file_path_str.startswith("<") and file_path_str.endswith(">")
+        ):
+            target_path = base_dir / target_path
+
+        if not (file_path_str.startswith("<") and file_path_str.endswith(">")) and not target_path.is_file():
+            line_number = source[: match.start()].count("\n") + 1
+            message = f'(SEVERE/4) File referenced in "include" directive not found: \'{file_path_str}\'.'
+            found_errors.append(types.LintError(source_origin=source_origin, line_number=line_number, message=message))
+
+        return ""
+
+    source = INCLUDE_REGEX.sub(replace_include, source)
+    return source, found_errors
+
+
 def _replace_ignored_substitutions(source: str, ignore_substitutions: list[str]) -> str:
     """Replace rst substitutions from the ignore list with a dummy.
 
@@ -202,6 +239,9 @@ def check_source(
             source, source_origin, warn_unknown_settings=warn_unknown_settings
         )
     )
+
+    source, include_errors = _process_include_directives(source, source_origin)
+    yield from include_errors
 
     source = _replace_ignored_substitutions(source, ignores["substitutions"])
 

--- a/src/rstcheck_core/checker.py
+++ b/src/rstcheck_core/checker.py
@@ -26,7 +26,7 @@ import docutils.nodes
 import docutils.utils
 import docutils.writers
 
-from . import _docutils, _extras, _sphinx, config, inline_config, types
+from . import _docutils, _extras, _sphinx, _sphinx_workarounds, config, inline_config, types
 
 try:
     import yaml
@@ -42,7 +42,6 @@ logger = logging.getLogger(__name__)
 EXCEPTION_LINE_NO_REGEX = re.compile(r": line\s+([0-9]+)[^:]*$")
 DOCTEST_LINE_NO_REGEX = re.compile(r"line ([0-9]+)")
 MARKDOWN_LINK_REGEX = re.compile(r"\[[^\]]+\]\([^\)]+\)")
-INCLUDE_REGEX = re.compile(r"^([ \t]*\.\.[ \t]+include::)[ \t]+(.+)$", flags=re.MULTILINE)
 
 
 def check_file(
@@ -131,54 +130,6 @@ def _get_source(source_file: pathlib.Path) -> str:
         return input_file.read()
 
 
-def _process_include_directives(
-    source: str, source_origin: types.SourceFileOrString
-) -> tuple[str, list[types.LintError]]:
-    """Strip include directives from source and check existence of included files.
-
-    This is a workaround for Sphinx which raises AttributeError on
-    encountering an include directive.
-
-    :param source: Source to remove include directives from
-    :param source_origin: Origin of the source
-    :return: Tuple of cleaned source and found errors
-    """
-    found_errors: list[types.LintError] = []
-
-    def replace_include(match: re.Match[str]) -> str:
-        file_path_str = match.group(2).strip()
-
-        if isinstance(source_origin, pathlib.Path) and source_origin.name != "-":
-            base_dir = source_origin.parent
-        else:
-            base_dir = pathlib.Path.cwd()
-
-        target_path = pathlib.Path(file_path_str)
-        if not target_path.is_absolute() and not (
-            file_path_str.startswith("<") and file_path_str.endswith(">")
-        ):
-            target_path = base_dir / target_path
-
-        if (
-            not (file_path_str.startswith("<") and file_path_str.endswith(">"))
-            and not target_path.is_file()
-        ):
-            line_number = source[: match.start()].count("\n") + 1
-            message = (
-                f"(SEVERE/4) File referenced in \"include\" directive not found: '{file_path_str}'."
-            )
-            found_errors.append(
-                types.LintError(
-                    source_origin=source_origin, line_number=line_number, message=message
-                )
-            )
-
-        return ""
-
-    source = INCLUDE_REGEX.sub(replace_include, source)
-    return source, found_errors
-
-
 def _replace_ignored_substitutions(source: str, ignore_substitutions: list[str]) -> str:
     """Replace rst substitutions from the ignore list with a dummy.
 
@@ -252,8 +203,8 @@ def check_source(
         )
     )
 
-    source, include_errors = _process_include_directives(source, source_origin)
-    yield from include_errors
+    yield from _sphinx_workarounds.yield_include_errors(source, source_origin, ignores["messages"])
+    source = _sphinx_workarounds.strip_include_directives(source)
 
     source = _replace_ignored_substitutions(source, ignores["substitutions"])
 

--- a/src/rstcheck_core/checker.py
+++ b/src/rstcheck_core/checker.py
@@ -203,8 +203,9 @@ def check_source(
         )
     )
 
-    yield from _sphinx_workarounds.yield_include_errors(source, source_origin, ignores["messages"])
-    source = _sphinx_workarounds.strip_include_directives(source)
+    if _extras.SPHINX_INSTALLED:
+        yield from _sphinx_workarounds.yield_include_errors(source, source_origin, ignores["messages"])
+        source = _sphinx_workarounds.strip_include_directives(source)
 
     source = _replace_ignored_substitutions(source, ignores["substitutions"])
 

--- a/tests/_sphinx_workarounds_test.py
+++ b/tests/_sphinx_workarounds_test.py
@@ -1,0 +1,153 @@
+"""Tests for ``_sphinx_workarounds`` module."""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+from rstcheck_core import _sphinx_workarounds
+
+
+def test_yield_include_errors_no_errors(tmp_path: pathlib.Path) -> None:
+    """Test include directive yields no errors when file exists."""
+    include_file = "exists.rst"
+    (tmp_path / include_file).write_text("Hello\n")
+    source = f".. include:: {include_file}"
+
+    result = list(
+        _sphinx_workarounds.yield_include_errors(source, source_origin=tmp_path / "test.rst")
+    )
+
+    assert not result
+
+
+def test_yield_include_errors_missing_file() -> None:
+    """Test include directive referencing non-existent file yields an error."""
+    source = ".. include:: does_not_exist.rst"
+
+    result = list(
+        _sphinx_workarounds.yield_include_errors(source, source_origin=pathlib.Path("test.rst"))
+    )
+
+    assert len(result) == 1
+    assert result[0]["line_number"] == 1
+    assert 'File referenced in "include" directive not found:' in result[0]["message"]
+    assert "does_not_exist.rst" in result[0]["message"]
+
+
+def test_strip_include_directives_no_options() -> None:
+    """Test include directive without options is stripped."""
+    source = """
+Some text before.
+
+.. include:: somefile.rst
+
+Some text after.
+"""
+    result = _sphinx_workarounds.strip_include_directives(source)
+
+    assert result == "\nSome text before.\n\n\n\nSome text after.\n"
+
+
+def test_strip_include_directives_with_options() -> None:
+    """Test include directive with options is stripped correctly and line count is preserved."""
+    source = """
+Some text before.
+
+.. include:: somefile.rst
+   :start-line: 1
+   :end-line: 10
+
+Some text after.
+"""
+    result = _sphinx_workarounds.strip_include_directives(source)
+
+    assert result == "\nSome text before.\n\n\n\n\n\nSome text after.\n"
+
+
+def test_strip_include_directives_with_other_content() -> None:
+    """Test with other indented content after."""
+    source = """
+  .. include:: somefile.rst
+     :start-line: 1
+     :end-line: 10
+
+  Some blockquote after.
+"""
+    result = _sphinx_workarounds.strip_include_directives(source)
+
+    assert result == "\n\n\n\n\n  Some blockquote after.\n"
+
+
+def test_strip_include_directives_with_unindented_field_list() -> None:
+    """Test include directive does not swallow unindented field lists after empty lines."""
+    source = """
+Bla.
+
+.. include:: other_file.rst
+
+:hello: this is not an include option
+
+Another paragraph.
+"""
+    result = _sphinx_workarounds.strip_include_directives(source)
+
+    assert result == "\nBla.\n\n\n\n:hello: this is not an include option\n\nAnother paragraph.\n"
+
+
+def test_strip_include_directives_with_indented_unrelated_content() -> None:
+    """Test indented include directive doesn't swallow unrelated same-level indented content."""
+    source = """
+Some text before.
+
+.. rst-class:: my-class
+
+    .. include:: other_file.txt
+
+    :hello: this is not an include option
+
+Some text after.
+"""
+    result = _sphinx_workarounds.strip_include_directives(source)
+
+    assert result == "\nSome text before.\n\n.. rst-class:: my-class\n\n\n\n    :hello: this is not an include option\n\nSome text after.\n"
+
+
+def test_changing_line_numbers_for_error_cases() -> None:
+    """Check that line numbers for errors match the source BEFORE AND AFTER stripping happens."""
+    source = """
+Some text.
+
+.. include:: does_not_exist.rst
+   :start-line: 1
+
+.. include:: does_not_exist_either.rst
+"""
+
+    errors = list(
+        _sphinx_workarounds.yield_include_errors(source, source_origin=pathlib.Path("test.rst"))
+    )
+
+    assert len(errors) == 2
+    assert errors[0]["line_number"] == 4
+    assert errors[1]["line_number"] == 7
+
+    stripped_source = _sphinx_workarounds.strip_include_directives(source)
+
+    assert stripped_source.count("\n") == source.count("\n")
+    assert stripped_source == "\nSome text.\n\n\n\n\n\n"
+
+
+def test_yield_include_errors_with_ignore_messages() -> None:
+    """Test include directive respects ignore_messages."""
+    source = ".. include:: does_not_exist.rst"
+
+    ignore_pattern = re.compile(r"File referenced in \"include\" directive not found")
+
+    result = list(
+        _sphinx_workarounds.yield_include_errors(
+            source, source_origin=pathlib.Path("test.rst"), ignore_messages=ignore_pattern
+        )
+    )
+
+    assert not result

--- a/tests/_sphinx_workarounds_test.py
+++ b/tests/_sphinx_workarounds_test.py
@@ -80,7 +80,7 @@ def test_strip_include_directives_with_other_content() -> None:
 
 
 def test_strip_include_directives_with_unindented_field_list() -> None:
-    """Test include directive does not swallow unindented field lists after empty lines."""
+    """Test include directive does not swallow trailing field list."""
     source = """
 Bla.
 

--- a/tests/_sphinx_workarounds_test.py
+++ b/tests/_sphinx_workarounds_test.py
@@ -110,7 +110,10 @@ Some text after.
 """
     result = _sphinx_workarounds.strip_include_directives(source)
 
-    assert result == "\nSome text before.\n\n.. rst-class:: my-class\n\n\n\n    :hello: this is not an include option\n\nSome text after.\n"
+    assert (
+        result
+        == "\nSome text before.\n\n.. rst-class:: my-class\n\n\n\n    :hello: this is not an include option\n\nSome text after.\n"
+    )
 
 
 def test_changing_line_numbers_for_error_cases() -> None:

--- a/tests/checker_test.py
+++ b/tests/checker_test.py
@@ -123,31 +123,6 @@ def test__replace_ignored_substitutions() -> None:
     assert result == "xSubstitution1x |Substitution2|"
 
 
-def test__include_directive(tmp_path: pathlib.Path) -> None:
-    """Test include directive yields no errors."""
-    include_file = "exists.rst"
-    (tmp_path / include_file).write_text("Hello\n")
-    source = f".. include:: {include_file}"
-
-    with _sphinx.load_sphinx_if_available():
-        result = list(checker.check_source(source, source_file=tmp_path / "test.rst"))
-
-    assert not result
-
-
-def test__include_directive_missing_file() -> None:
-    """Test include directive referencing non-existent file yields a Severe error."""
-    source = ".. include:: does_not_exist.rst"
-
-    with _sphinx.load_sphinx_if_available():
-        result = list(checker.check_source(source, source_file=pathlib.Path("test.rst")))
-
-    assert len(result) == 1
-    assert result[0]["line_number"] == 1
-    assert 'File referenced in "include" directive not found:' in result[0]["message"]
-    assert "does_not_exist.rst" in result[0]["message"]
-
-
 def test__create_ignore_dict_from_config() -> None:
     """Test ``_create_ignore_dict_from_config`` function creates ignore dict."""
     ignore_messages = r"foo/bar"

--- a/tests/checker_test.py
+++ b/tests/checker_test.py
@@ -221,6 +221,35 @@ Test
 
     @staticmethod
     @pytest.mark.skipif(_extras.SPHINX_INSTALLED, reason="Test without sphinx extra.")
+    def test_include_directive_without_sphinx(tmp_path: pathlib.Path, monkeypatch) -> None:
+        """Test error on include directive when sphinx is missing."""
+        monkeypatch.chdir(tmp_path)
+        include_file = "exists.rst"
+        (tmp_path / include_file).write_text("Hello\n")
+        source = f"""
+.. include:: {include_file}
+"""
+
+        result = list(checker.check_source(source))
+
+        assert not result
+
+    @staticmethod
+    @pytest.mark.skipif(_extras.SPHINX_INSTALLED, reason="Test without sphinx extra.")
+    def test_include_directive_error_without_sphinx() -> None:
+        """Test error on include directive with non-existing file when sphinx is missing."""
+        source = """
+.. include:: doesnt_exist.rst
+"""
+
+        result = list(checker.check_source(source))
+        print(result)
+
+        assert len(result) > 0
+        assert '(SEVERE/4) Problems with "include" directive path:' in result[0]["message"]
+
+    @staticmethod
+    @pytest.mark.skipif(_extras.SPHINX_INSTALLED, reason="Test without sphinx extra.")
     def test_sphinx_directive_errors_without_sphinx() -> None:
         """Test error on sphinx directive when sphinx is missing."""
         source = """

--- a/tests/checker_test.py
+++ b/tests/checker_test.py
@@ -224,7 +224,7 @@ Test
     def test_include_directive_without_sphinx(
         tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Test error on include directive when sphinx is missing."""
+        """Test include directive when sphinx is missing."""
         monkeypatch.chdir(tmp_path)
         include_file = "exists.rst"
         (tmp_path / include_file).write_text("Hello\n")

--- a/tests/checker_test.py
+++ b/tests/checker_test.py
@@ -221,7 +221,9 @@ Test
 
     @staticmethod
     @pytest.mark.skipif(_extras.SPHINX_INSTALLED, reason="Test without sphinx extra.")
-    def test_include_directive_without_sphinx(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_include_directive_without_sphinx(
+        tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Test error on include directive when sphinx is missing."""
         monkeypatch.chdir(tmp_path)
         include_file = "exists.rst"

--- a/tests/checker_test.py
+++ b/tests/checker_test.py
@@ -221,7 +221,7 @@ Test
 
     @staticmethod
     @pytest.mark.skipif(_extras.SPHINX_INSTALLED, reason="Test without sphinx extra.")
-    def test_include_directive_without_sphinx(tmp_path: pathlib.Path, monkeypatch) -> None:
+    def test_include_directive_without_sphinx(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test error on include directive when sphinx is missing."""
         monkeypatch.chdir(tmp_path)
         include_file = "exists.rst"
@@ -243,7 +243,6 @@ Test
 """
 
         result = list(checker.check_source(source))
-        print(result)
 
         assert len(result) > 0
         assert '(SEVERE/4) Problems with "include" directive path:' in result[0]["message"]

--- a/tests/checker_test.py
+++ b/tests/checker_test.py
@@ -123,6 +123,31 @@ def test__replace_ignored_substitutions() -> None:
     assert result == "xSubstitution1x |Substitution2|"
 
 
+def test__include_directive(tmp_path: pathlib.Path) -> None:
+    """Test include directive yields no errors."""
+    include_file = "exists.rst"
+    (tmp_path / include_file).write_text("Hello\n")
+    source = f".. include:: {include_file}"
+
+    with _sphinx.load_sphinx_if_available():
+        result = list(checker.check_source(source, source_file=tmp_path / "test.rst"))
+
+    assert not result
+
+
+def test__include_directive_missing_file() -> None:
+    """Test include directive referencing non-existent file yields a Severe error."""
+    source = ".. include:: does_not_exist.rst"
+
+    with _sphinx.load_sphinx_if_available():
+        result = list(checker.check_source(source, source_file=pathlib.Path("test.rst")))
+
+    assert len(result) == 1
+    assert result[0]["line_number"] == 1
+    assert 'File referenced in "include" directive not found:' in result[0]["message"]
+    assert "does_not_exist.rst" in result[0]["message"]
+
+
 def test__create_ignore_dict_from_config() -> None:
     """Test ``_create_ignore_dict_from_config`` function creates ignore dict."""
     ignore_messages = r"foo/bar"


### PR DESCRIPTION
This PR implements a workaround for the AttributeError crash caused by Sphinx when evaluating '.. include::'. It replaces the include directives with blank lines and manually checks for the existence of included files, yielding a Severe error if they are missing.

This PR was drafted by Gemini CLI and I reviewed it. One caveat is that only the first line of the include directive is replaced with a blank line. If the directive has any options on the lines following it, these are left behind. From my preliminary tests, these do not cause any harm, but it would be better to also replace these with blank lines.
